### PR TITLE
Little improve position save/load & major code refactor & other changes

### DIFF
--- a/kangur/ActionsManager.cs
+++ b/kangur/ActionsManager.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace kangur
+{
+    public class ActionsManager
+    {
+        private Dictionary<int, Action> _registeredActions; // KeyCode, Action
+
+        public ActionsManager()
+        {
+            _registeredActions = new Dictionary<int, Action>();
+        }
+
+        public void RegisterAction(int keyCode, Action action)
+        {
+            if (_registeredActions.ContainsKey(keyCode)) return;
+            if (action == null) return;
+
+            _registeredActions.Add(keyCode, action);
+        }
+
+        public void CallAction(int keyCode)
+        {
+            if (!_registeredActions.ContainsKey(keyCode)) return;
+
+            _registeredActions[keyCode]?.Invoke();
+        }
+    }
+}

--- a/kangur/GamepadButtonSelect.cs
+++ b/kangur/GamepadButtonSelect.cs
@@ -1,11 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace kangur

--- a/kangur/Hero.cs
+++ b/kangur/Hero.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Numerics;
+
+namespace kangur
+{
+    public class Hero
+    {
+        public Vector3 HeroPosition
+        { 
+            get
+            {
+                uint heroPointer = Main.MainWindow.PointersData.HeroPointer;
+
+                float posX = Toolkit.ReadMemoryFloat(heroPointer + 0x58);
+                float posY = Toolkit.ReadMemoryFloat(heroPointer + 0x5C);
+                float posZ = Toolkit.ReadMemoryFloat(heroPointer + 0x60);
+
+                _playerPosition = new Vector3(posX, posY, posZ);
+                return _playerPosition;
+            }
+            set
+            {
+                _playerPosition = value;
+            }
+        }
+
+        private Vector3 _playerPosition;
+
+        public Vector2 HeroRotation
+        {
+            get
+            {
+                uint heroPointer = Main.MainWindow.PointersData.HeroPointer;
+
+                float rotX = Toolkit.ReadMemoryFloat(heroPointer + 0x50);
+                float rotY = Toolkit.ReadMemoryFloat(heroPointer + 0x54);
+
+                _playerRotation = new Vector2(rotX, rotY);
+                return _playerRotation;
+            }
+            set
+            {
+                _playerRotation = value;
+            }
+        }
+        private Vector2 _playerRotation;
+
+        public void SaveHeroTransformToMemory()
+        {
+            // convert to byte array for faster writings and single execution style
+            byte[] rotX = BitConverter.GetBytes(_playerRotation.X);
+            byte[] rotY = BitConverter.GetBytes(_playerRotation.Y);
+            byte[] posX = BitConverter.GetBytes(_playerPosition.X);
+            byte[] posY = BitConverter.GetBytes(_playerPosition.Y);
+            byte[] posZ = BitConverter.GetBytes(_playerPosition.Z);
+
+            // merge byte arrays
+            byte[] fullByteTable = Toolkit.MergeByteArrays(rotX, rotY, posX, posY, posZ);
+
+            // write full vector5 position as byte arary
+            Toolkit.WriteMemory(Main.MainWindow.PointersData.PositionPointer, fullByteTable);
+        }
+
+    }
+}

--- a/kangur/Hotkeys.cs
+++ b/kangur/Hotkeys.cs
@@ -1,11 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace kangur

--- a/kangur/ModuleEnvironment.Designer.cs
+++ b/kangur/ModuleEnvironment.Designer.cs
@@ -38,7 +38,7 @@
             // 
             // comboBoxLevelSelect
             // 
-            this.comboBoxLevelSelect.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
+            this.comboBoxLevelSelect.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxLevelSelect.FormattingEnabled = true;
             this.comboBoxLevelSelect.Items.AddRange(new object[] {
             "The Ship",

--- a/kangur/ModuleEnvironment.cs
+++ b/kangur/ModuleEnvironment.cs
@@ -1,11 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace kangur

--- a/kangur/ModuleHero.Designer.cs
+++ b/kangur/ModuleHero.Designer.cs
@@ -78,6 +78,8 @@
             this.textBoxRotX.Size = new System.Drawing.Size(84, 20);
             this.textBoxRotX.TabIndex = 6;
             this.textBoxRotX.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.textBoxRotX.TextChanged += new System.EventHandler(this.TransformTextBox_TextChanged);
+            this.textBoxRotX.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TransformTextBox_KeyPress);
             // 
             // label2
             // 
@@ -104,6 +106,8 @@
             this.textBoxRotY.Size = new System.Drawing.Size(84, 20);
             this.textBoxRotY.TabIndex = 8;
             this.textBoxRotY.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.textBoxRotY.TextChanged += new System.EventHandler(this.TransformTextBox_TextChanged);
+            this.textBoxRotY.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TransformTextBox_KeyPress);
             // 
             // label4
             // 
@@ -121,6 +125,8 @@
             this.textBoxPosX.Size = new System.Drawing.Size(84, 20);
             this.textBoxPosX.TabIndex = 10;
             this.textBoxPosX.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.textBoxPosX.TextChanged += new System.EventHandler(this.TransformTextBox_TextChanged);
+            this.textBoxPosX.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TransformTextBox_KeyPress);
             // 
             // label5
             // 
@@ -138,6 +144,8 @@
             this.textBoxPosY.Size = new System.Drawing.Size(84, 20);
             this.textBoxPosY.TabIndex = 12;
             this.textBoxPosY.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.textBoxPosY.TextChanged += new System.EventHandler(this.TransformTextBox_TextChanged);
+            this.textBoxPosY.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TransformTextBox_KeyPress);
             // 
             // label6
             // 
@@ -155,6 +163,8 @@
             this.textBoxPosZ.Size = new System.Drawing.Size(84, 20);
             this.textBoxPosZ.TabIndex = 14;
             this.textBoxPosZ.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.textBoxPosZ.TextChanged += new System.EventHandler(this.TransformTextBox_TextChanged);
+            this.textBoxPosZ.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TransformTextBox_KeyPress);
             // 
             // buttonSnapshot
             // 

--- a/kangur/PointersData.cs
+++ b/kangur/PointersData.cs
@@ -1,0 +1,16 @@
+﻿namespace kangur
+{
+    public struct PointersData
+    {
+        public uint GameletPointer { get; private set; }
+        public uint HeroPointer { get; private set; }
+        public uint PositionPointer { get; private set; }
+
+        public PointersData(uint gameletPointer)
+        {
+            GameletPointer = gameletPointer;
+            HeroPointer = Toolkit.ReadMemoryInt32(GameletPointer + 0x38C);
+            PositionPointer = Toolkit.ReadMemoryInt32(GameletPointer + 0x38C) + 0x50;
+        }
+    }
+}

--- a/kangur/Program.cs
+++ b/kangur/Program.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace kangur

--- a/kangur/Toolkit.cs
+++ b/kangur/Toolkit.cs
@@ -1,19 +1,21 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace kangur
 {
-    // cool and useful functions
-    class Toolkit
+    /// <summary>
+    /// Cool and useful functions.
+    /// </summary>
+    public static class Toolkit
     {
-        // check if window = form is already open
-        public bool IsFormOpen(string name)
+        /// <summary>
+        /// Check if window = form is already open
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public static bool IsFormOpen(string name)
         {
             // go through all of the forms
             foreach (Form window in Application.OpenForms)
@@ -27,8 +29,12 @@ namespace kangur
             return false;
         }
 
-        // check if form is visible
-        public bool IsFormVisible(string name)
+        /// <summary>
+        /// Check if form is visible
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public static bool IsFormVisible(string name)
         {
             // go through all of the forms
             foreach (Form window in Application.OpenForms)
@@ -43,19 +49,29 @@ namespace kangur
             return false;
         }
 
-        // change memory protection
-        public bool DisableMemoryProtection(uint address, int size)
+        /// <summary>
+        /// Change memory protection.
+        /// </summary>
+        /// <param name="address"></param>
+        /// <param name="size"></param>
+        /// <returns></returns>
+        public static bool DisableMemoryProtection(uint address, int size)
         { return VirtualProtectEx(Main.mainGameProcess.Handle, (IntPtr)address, size, 0x40, out IntPtr zero); }
 
-        // write memory easily, a cool wrapper
-        public bool WriteMemory(uint address, byte[] array)
+        /// <summary>
+        /// Write memory easily, a cool wrapper.
+        /// </summary>
+        /// <param name="address"></param>
+        /// <param name="array"></param>
+        /// <returns></returns>
+        public static bool WriteMemory(uint address, byte[] array)
         {
             // longer function in wrapper
             return WriteProcessMemory(Main.mainGameProcess.Handle, (IntPtr)address,
                 array, array.Length, out IntPtr nullification);
         }
 
-        public uint ReadMemoryInt32(uint address)
+        public static uint ReadMemoryInt32(uint address)
         {
             // 4 because int is 4
             byte[] rawBytes = new byte[4];
@@ -68,8 +84,12 @@ namespace kangur
             return BitConverter.ToUInt32(rawBytes, 0);
         }
 
-        // reads float value from memory
-        public float ReadMemoryFloat(uint address)
+        /// <summary>
+        /// Reads float value from memory.
+        /// </summary>
+        /// <param name="address"></param>
+        /// <returns></returns>
+        public static float ReadMemoryFloat(uint address)
         {
             // 4 because float is 4
             byte[] rawBytes = new byte[4];
@@ -82,23 +102,29 @@ namespace kangur
             return BitConverter.ToSingle(rawBytes, 0);
         }
 
-        // allocates memory
-        public uint AllocateMemory()
+        /// <summary>
+        /// Allocates memory.
+        /// </summary>
+        /// <returns></returns>
+        public static uint AllocateMemory()
         { return (uint)VirtualAllocEx(Main.mainGameProcess.Handle, IntPtr.Zero, 0x1000, 0x1000 | 0x2000, 0x40); }
 
         // checks if key is pressed
-        public bool IsKeyPressed(int keyCode)
+        public static bool IsKeyPressed(int keyCode)
         {
             // read key status from table and compare
             short keyStatus = GetAsyncKeyState(keyCode);
 
             // return if pressed
-            if ((keyStatus & 1) != 0) return true;
-            else return false;
+            return (keyStatus & 1) != 0;
         }
 
-        // merging byte arrays with concat
-        public byte[] MergeByteArrays(params byte[][] arrays)
+        /// <summary>
+        /// Merging byte arrays with concat.
+        /// </summary>
+        /// <param name="arrays"></param>
+        /// <returns></returns>
+        public static byte[] MergeByteArrays(params byte[][] arrays)
         {
             // create empty array
             byte[] byteArray = new byte[0];
@@ -110,6 +136,10 @@ namespace kangur
             // returned merged arrays
             return byteArray;
         }
+
+        // show custom message box with warning or error icon
+        public static void ShowError(string message) { MessageBox.Show(message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error); }
+        public static void ShowInfo(string message) { MessageBox.Show(message, "Info", MessageBoxButtons.OK, MessageBoxIcon.Information); }
 
         // imported protection change
         [DllImport("kernel32.dll", SetLastError = true)]

--- a/kangur/Updates.cs
+++ b/kangur/Updates.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace kangur

--- a/kangur/X.cs
+++ b/kangur/X.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace kangur
 {


### PR DESCRIPTION
- Dont need launching the hero window to use hotkeys from saving/loading the Kao's position.
- List with levels is now read only.
- Allow only numeric input in text boxs with position and rotation.
- Delete unused namespaces.
- Major code refactor.